### PR TITLE
Add missing/broken imgui & mgbdis submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "runtime/third_party/imgui"]
 	path = runtime/third_party/imgui
 	url = https://github.com/ocornut/imgui.git
+[submodule "tools/mgbdis"]
+	path = tools/mgbdis
+	url = https://github.com/mattcurrie/mgbdis.git


### PR DESCRIPTION
Fixes missing/broken imgui and mgbdis submodules

i noticed tools/mgbdis is on .gitignore, but it was also setup as a submodule, so i'm not entirely sure if it's needed for anything?