### PR TITLE
README.md: Added linux specific instuctions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,32 @@ cmake -S output/game -B output/game/build -DGBRECOMP_GENERATED_OPT_LEVEL=2
 
 ### Automated Setup (Recommended)
 
-**macOS/Linux:**
+**macOS:**
 ```bash
 # Download and run the setup script
 git clone https://github.com/arcanite24/gb-recompiled.git
 cd gb-recompiled
+chmod +x tools/setup.sh
+./tools/setup.sh
+```
+
+**Linux:**
+
+First install build dependencies:
+- git
+- build-essential
+- cmake
+- ninja-build
+- python3 
+- python3-pip
+- python3-venv
+- libsdl2-dev
+```bash
+# Download the setup script, create a venv for python packages, and run the setup
+git clone https://github.com/arcanite24/gb-recompiled.git
+cd gb-recompiled
+python3 -m venv gb
+source gb/bin/activate
 chmod +x tools/setup.sh
 ./tools/setup.sh
 ```


### PR DESCRIPTION
Cool project.

The goal of this PR is to add some clarification for building in Linux. I have tested the build under Linux and can confirm that it works as intended. I've even built a few games myself.

This was tested within a Ubuntu 24 Environment.

I also chose to include instructions for making a python virtual environment. Without one, pip will throw an error when trying to execute your setup script. This is generally considered good practice since you don't want every part of the workflow to be installed as system wide packages.

This will probably need some clarification further down in the README that if you setup this way under Linux you'll need to activate it again to run the Automated analysis workflows provided.